### PR TITLE
[Feature] Daily 탄소 소비 조회 기능

### DIFF
--- a/server/src/main/java/com/soopgyeol/api/controller/UserCarbonLogController.java
+++ b/server/src/main/java/com/soopgyeol/api/controller/UserCarbonLogController.java
@@ -2,13 +2,15 @@ package com.soopgyeol.api.controller;
 
 import com.soopgyeol.api.common.dto.ApiResponse;
 import com.soopgyeol.api.domain.usercarbonlog.dto.UserCarbonLogRequest;
+import com.soopgyeol.api.domain.usercarbonlog.dto.UserCarbonLogResponse;
 import com.soopgyeol.api.service.carbonlog.UserCarbonLogService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/carbon/log")
@@ -22,4 +24,12 @@ public class UserCarbonLogController {
         return ResponseEntity.ok(new ApiResponse<>(true, "탄소 소비 기록 저장 완료", null));
     }
 
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponse<List<UserCarbonLogResponse>>> getLogsByDate(
+            @RequestParam Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        List<UserCarbonLogResponse> logs = userCarbonLogService.getLogsByUserIdAndDate(userId, date);
+        return ResponseEntity.ok(new ApiResponse<>(true, "조회 성공", logs));
+    }
 }

--- a/server/src/main/java/com/soopgyeol/api/domain/usercarbonlog/dto/UserCarbonLogResponse.java
+++ b/server/src/main/java/com/soopgyeol/api/domain/usercarbonlog/dto/UserCarbonLogResponse.java
@@ -1,0 +1,11 @@
+package com.soopgyeol.api.domain.usercarbonlog.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserCarbonLogResponse {
+    private String product;
+    private int growthPoint;
+}

--- a/server/src/main/java/com/soopgyeol/api/domain/usercarbonlog/entity/UserCarbonLog.java
+++ b/server/src/main/java/com/soopgyeol/api/domain/usercarbonlog/entity/UserCarbonLog.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -38,5 +39,5 @@ public class UserCarbonLog {
     private int growthPoint;
 
     @Column(nullable = false)
-    private LocalDate recordedAt;
+    private LocalDateTime recordedAt;
 }

--- a/server/src/main/java/com/soopgyeol/api/repository/UserCarbonLogRepository.java
+++ b/server/src/main/java/com/soopgyeol/api/repository/UserCarbonLogRepository.java
@@ -2,6 +2,17 @@ package com.soopgyeol.api.repository;
 
 import com.soopgyeol.api.domain.usercarbonlog.entity.UserCarbonLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface UserCarbonLogRepository extends JpaRepository<UserCarbonLog, Long> {
+
+    List <UserCarbonLog> findByUserIdAndRecordedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT COALESCE(SUM(u.calculatedCarbon), 0) FROM UserCarbonLog u WHERE u.user.id = :userId AND DATE(u.recordedAt) = :date")
+    float findTotalCarbonByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/server/src/main/java/com/soopgyeol/api/repository/UserCarbonLogRepository.java
+++ b/server/src/main/java/com/soopgyeol/api/repository/UserCarbonLogRepository.java
@@ -13,6 +13,4 @@ public interface UserCarbonLogRepository extends JpaRepository<UserCarbonLog, Lo
 
     List <UserCarbonLog> findByUserIdAndRecordedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
-    @Query("SELECT COALESCE(SUM(u.calculatedCarbon), 0) FROM UserCarbonLog u WHERE u.user.id = :userId AND DATE(u.recordedAt) = :date")
-    float findTotalCarbonByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/server/src/main/java/com/soopgyeol/api/service/carbonlog/UserCarbonLogService.java
+++ b/server/src/main/java/com/soopgyeol/api/service/carbonlog/UserCarbonLogService.java
@@ -1,7 +1,13 @@
 package com.soopgyeol.api.service.carbonlog;
 
 import com.soopgyeol.api.domain.usercarbonlog.dto.UserCarbonLogRequest;
+import com.soopgyeol.api.domain.usercarbonlog.dto.UserCarbonLogResponse;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface UserCarbonLogService {
     void saveCarbonLog(UserCarbonLogRequest request);
+
+    List<UserCarbonLogResponse> getLogsByUserIdAndDate(Long userId, LocalDate date);
 }

--- a/server/src/main/java/com/soopgyeol/api/service/carbonlog/UserCarbonLogServiceImpl.java
+++ b/server/src/main/java/com/soopgyeol/api/service/carbonlog/UserCarbonLogServiceImpl.java
@@ -3,6 +3,7 @@ package com.soopgyeol.api.service.carbonlog;
 import com.soopgyeol.api.domain.carbon.entity.CarbonItem;
 import com.soopgyeol.api.domain.user.User;
 import com.soopgyeol.api.domain.usercarbonlog.dto.UserCarbonLogRequest;
+import com.soopgyeol.api.domain.usercarbonlog.dto.UserCarbonLogResponse;
 import com.soopgyeol.api.domain.usercarbonlog.entity.UserCarbonLog;
 import com.soopgyeol.api.repository.CarbonItemRepository;
 import com.soopgyeol.api.repository.UserCarbonLogRepository;
@@ -11,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -36,9 +40,24 @@ public class UserCarbonLogServiceImpl implements UserCarbonLogService{
                 .quantity(request.getQuantity())
                 .calculatedCarbon(totalCarbon)
                 .growthPoint(totalGrowthPoint)
-                .recordedAt(LocalDate.now())
+                .recordedAt(LocalDateTime.now())
                 .build();
 
         carbonLogRepository.save(log);
+    }
+
+    public List<UserCarbonLogResponse> getLogsByUserIdAndDate(Long userId, LocalDate date){
+        // 날짜 기준으로 시작/끝 시간
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        List<UserCarbonLog> logs = carbonLogRepository.findByUserIdAndRecordedAtBetween(userId, startOfDay, endOfDay);
+
+        return logs.stream()
+                .map(log -> UserCarbonLogResponse.builder()
+                        .product(log.getCarbonItem().getName())
+                        .growthPoint(log.getGrowthPoint())
+                        .build())
+                .toList();
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update #create
+      ddl-auto: create #create
     show-sql: true
     properties:
       hibernate:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create #create
+      ddl-auto: update #create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
### ⛓️‍💥 Issue Number
- #18 

  <br/>
### 🔎 Summary

- 사용자가 달력에서 특정 날짜 선택 시, 해당 날짜에 관련한 모든 탄소 소비 기록을 조회합니다.
- 조회할 정보는 피그마 UI와 같이 품목명과 성장 포인트로 제한되어 있습니다.
- 테스트 할 때 ddl-auto는 create로 바꾸고 하는 것을 권장드립니다.

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

  <br/>
### ✅ PR 체크 리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [ ] test workflow가 정상적으로 작동했습니다.
