### PR TITLE
[Refactor] prod,dev yml 추가 설정

### DIFF
--- a/server/src/main/java/com/soopgyeol/api/controller/AuthController.java
+++ b/server/src/main/java/com/soopgyeol/api/controller/AuthController.java
@@ -12,11 +12,15 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth/oauth")
 public class AuthController {
+
+    @Value("${oauth.redirect.frontend-url}")
+    private String frontendRedirectUrl;
 
     private final OAuthService oAuthService;
     private final GoogleOauth googleOauth;
@@ -39,15 +43,13 @@ public class AuthController {
         return ResponseEntity.ok(Map.of("url", url));
     }
 
-    // 구글 로그인 성공 후 리디렉트 → code만 프론트로 전달
     @GetMapping("/oauth2/google/code-log")
     public void googleAutoLogin(@RequestParam String code, HttpServletResponse response) throws IOException {
-        response.sendRedirect("http://localhost:3000/oauth?code=" + code);
+        response.sendRedirect(frontendRedirectUrl + "?code=" + code);
     }
 
-    // 카카오 로그인 성공 후 리디렉트 → code만 프론트로 전달
     @GetMapping("/oauth2/kakao/code-log")
     public void kakaoAutoLogin(@RequestParam String code, HttpServletResponse response) throws IOException {
-        response.sendRedirect("http://localhost:3000/oauth?code=" + code);
+        response.sendRedirect(frontendRedirectUrl + "?code=" + code);
     }
 }

--- a/server/src/main/java/com/soopgyeol/api/controller/UserController.java
+++ b/server/src/main/java/com/soopgyeol/api/controller/UserController.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor

--- a/server/src/main/java/com/soopgyeol/api/service/jwt/JwtProvider.java
+++ b/server/src/main/java/com/soopgyeol/api/service/jwt/JwtProvider.java
@@ -72,7 +72,3 @@ public class JwtProvider {
 }
 
 
-
-        return Long.valueOf(claims.getSubject());
-    }
-}

--- a/server/src/main/resources/ application-prod.yml
+++ b/server/src/main/resources/ application-prod.yml
@@ -1,0 +1,3 @@
+oauth:
+  redirect:
+    frontend-url: https://your-frontend.com/oauth/callback # 추후 리다이렉트 할 프론트 주소

--- a/server/src/main/resources/application-dev.yml
+++ b/server/src/main/resources/application-dev.yml
@@ -1,0 +1,3 @@
+oauth:
+  redirect:
+    frontend-url: http://localhost:3000/oauth/callback

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -34,6 +34,9 @@ oauth:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
 
+  redirect:
+    frontend-url: http://localhost:3000/oauth/callback
+
 jwt:
   secret: ${JWT_SECRET}
 


### PR DESCRIPTION
### ⛓️‍💥 Issue Number
- #38 


  <br/>
### 🔎 Summary

- 로그인 시 localhost 가 뜨는 상황을 위해 설정
- 로그인 직후 연결된 페이지가 없어서 생기는 문제이나, 배포 서버에서 원활히 보여지기 위해 로컬 주소로 리다이렉트 되도록 하드코딩 된 부분을 yml을 이용해 특정 서버 주소로 리다이렉트 되도록 수정했습니다.

- 리디렉트 URL은 환경별로 구분됩니다.
  - dev: http://localhost:3000/oauth/callback
  - prod: https://your-frontend.com/oauth/callback

✅ 프론트 처리 요청
- /oauth/callback 페이지를 만들어주세요.
  - URL 쿼리에서 ?code=xxx 값 읽기
  - /api/v1/auth/oauth/login API에 POST 요청
    {
      "provider": "KAKAO" 또는 "GOOGLE",
      "code": "xxx"
    }
  - 응답으로 받은 JWT를 localStorage에 저장
  - 로그인 완료 후 메인화면으로 이동

필요 시 테스트용 localhost 리디렉트 URL 사용 가능합니다.


- **dev.yml과 공통 yml이 중복되는 것처럼 보이나, 추후 개발용/서버용 yml을 사용할 일이 있을 것 같아 합치지 않았습니다.**

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

  <br/>
### ✅ PR 체크 리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [ ] test workflow가 정상적으로 작동했습니다.

  <br/>
 ### 📸 스크린샷 (선택)