### PR TITLE
[Feature] 챌린지 키워드 기반 AI 탄소 검색

### DIFF
--- a/server/src/main/java/com/soopgyeol/api/controller/CarbonItemController.java
+++ b/server/src/main/java/com/soopgyeol/api/controller/CarbonItemController.java
@@ -3,6 +3,7 @@ package com.soopgyeol.api.controller;
 import com.soopgyeol.api.common.dto.ApiResponse;
 import com.soopgyeol.api.domain.carbon.dto.CarbonAnalysisRequest;
 import com.soopgyeol.api.domain.carbon.dto.CarbonAnalysisResponse;
+import com.soopgyeol.api.domain.challenge.dto.AIChallengeSendingRequest;
 import com.soopgyeol.api.service.carbon.CarbonAnalysisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,5 +28,12 @@ public class CarbonItemController {
         Long userId = userDetails.getUserId();
         CarbonAnalysisResponse response = carbonAnalysisService.analyzeAndSave(request.getUserInput(), userId);
         return ResponseEntity.ok(new ApiResponse<>(true, "검색 성공", response));
+    }
+
+
+    @PostMapping("/analyze/keyword")
+    public ResponseEntity<ApiResponse<CarbonAnalysisResponse>> analyzeByKeyword(@RequestBody AIChallengeSendingRequest request) {
+        CarbonAnalysisResponse response = carbonAnalysisService.analyzeByKeyword(request.getKeyword(), request.getCategory()); // 저장 없이 반환
+        return ResponseEntity.ok(new ApiResponse<>(true, "챌린지 기반 검색 성공", response));
     }
 }

--- a/server/src/main/java/com/soopgyeol/api/controller/DailyChallengeController.java
+++ b/server/src/main/java/com/soopgyeol/api/controller/DailyChallengeController.java
@@ -21,11 +21,8 @@ public class DailyChallengeController {
 
     @GetMapping("/today")
     public ResponseEntity<ApiResponse<ChallengeTodayResponse>> getOrCreateTodayChallenge (
-            @RequestParam Long userId
-            //         @AuthenticationPrincipal CustomUserDetails userDetails
-
-    ){
-        ChallengeTodayResponse dto = userChallengeService.getTodayChallengeForUser(userId);
+           @AuthenticationPrincipal CustomUserDetails userDetails){
+        ChallengeTodayResponse dto = userChallengeService.getTodayChallengeForUser(userDetails.getUserId());
         return ResponseEntity.ok(new ApiResponse<>(true, "오늘의 챌린지 조회 성공", dto));
     }
 }

--- a/server/src/main/java/com/soopgyeol/api/controller/DailyChallengeController.java
+++ b/server/src/main/java/com/soopgyeol/api/controller/DailyChallengeController.java
@@ -21,8 +21,11 @@ public class DailyChallengeController {
 
     @GetMapping("/today")
     public ResponseEntity<ApiResponse<ChallengeTodayResponse>> getOrCreateTodayChallenge (
-             @AuthenticationPrincipal CustomUserDetails userDetails){
-        ChallengeTodayResponse dto = userChallengeService.getTodayChallengeForUser(userDetails.getUserId());
+            @RequestParam Long userId
+            //         @AuthenticationPrincipal CustomUserDetails userDetails
+
+    ){
+        ChallengeTodayResponse dto = userChallengeService.getTodayChallengeForUser(userId);
         return ResponseEntity.ok(new ApiResponse<>(true, "오늘의 챌린지 조회 성공", dto));
     }
 }

--- a/server/src/main/java/com/soopgyeol/api/domain/carbon/dto/CarbonAnalysisResponse.java
+++ b/server/src/main/java/com/soopgyeol/api/domain/carbon/dto/CarbonAnalysisResponse.java
@@ -18,4 +18,5 @@ public class CarbonAnalysisResponse {
     private String categoryKorean;   // 카테고리(한글)
     private int growthPoint; // 단위당 성장 점수
     private String explanation;      // 왜 이 정도 탄소가 나왔는지 설명
+    private String categoryImageUrl;
 }

--- a/server/src/main/java/com/soopgyeol/api/domain/challenge/dto/AIChallengeSendingRequest.java
+++ b/server/src/main/java/com/soopgyeol/api/domain/challenge/dto/AIChallengeSendingRequest.java
@@ -1,0 +1,10 @@
+package com.soopgyeol.api.domain.challenge.dto;
+
+import com.soopgyeol.api.domain.enums.Category;
+import lombok.Data;
+
+@Data
+public class AIChallengeSendingRequest {
+    String keyword;
+    Category category;
+}

--- a/server/src/main/java/com/soopgyeol/api/service/carbon/CarbonAnalysisService.java
+++ b/server/src/main/java/com/soopgyeol/api/service/carbon/CarbonAnalysisService.java
@@ -1,7 +1,10 @@
 package com.soopgyeol.api.service.carbon;
 
 import com.soopgyeol.api.domain.carbon.dto.CarbonAnalysisResponse;
+import com.soopgyeol.api.domain.enums.Category;
 
 public interface CarbonAnalysisService {
     CarbonAnalysisResponse analyzeAndSave(String userInput, Long userId);
+
+    CarbonAnalysisResponse analyzeByKeyword(String keyword, Category category);
 }

--- a/server/src/main/java/com/soopgyeol/api/service/carbon/CarbonAnalysisServiceImpl.java
+++ b/server/src/main/java/com/soopgyeol/api/service/carbon/CarbonAnalysisServiceImpl.java
@@ -2,7 +2,9 @@ package com.soopgyeol.api.service.carbon;
 
 import com.soopgyeol.api.domain.carbon.dto.CarbonAnalysisResponse;
 import com.soopgyeol.api.domain.carbon.entity.CarbonItem;
+import com.soopgyeol.api.domain.enums.Category;
 import com.soopgyeol.api.repository.CarbonItemRepository;
+import com.soopgyeol.api.service.gpt.AIChallengeSearchService;
 import com.soopgyeol.api.service.gpt.OpenAiService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ import java.time.LocalDateTime;
 public class CarbonAnalysisServiceImpl implements CarbonAnalysisService {
     private final OpenAiService openAiService;
     private final CarbonItemRepository carbonItemRepository;
+    private final AIChallengeSearchService aiChallengeSearchService;
 
     @Override
     public CarbonAnalysisResponse analyzeAndSave(String userInput, Long userId) {
@@ -41,6 +44,40 @@ public class CarbonAnalysisServiceImpl implements CarbonAnalysisService {
                 .carbonGrams(savedItem.getCarbonValue())
                 .growthPoint(savedItem.getGrowthPoint())
                 .explanation(savedItem.getExplanation())
+                .categoryImageUrl(savedItem.getCategory().getImageUrl())
+                .build();
+    }
+
+    @Override
+    public CarbonAnalysisResponse analyzeByKeyword(String keyword, Category category) {
+        // 1. GPT로 분석 요청 (챌린지에서 제공한 키워드 기반)
+        CarbonAnalysisResponse analysis = aiChallengeSearchService.analyzeWithFixedCategory(keyword, category);
+
+
+        analysis.setCategoryKorean(analysis.getCategory().getDescription());
+
+
+        CarbonItem carbonItem = CarbonItem.builder()
+                .name(analysis.getName())
+                .category(analysis.getCategory())
+                .carbonValue((float) analysis.getCarbonGrams())
+                .growthPoint(analysis.getGrowthPoint())
+                .explanation(analysis.getExplanation())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        CarbonItem savedItem = carbonItemRepository.save(carbonItem);
+
+
+        return CarbonAnalysisResponse.builder()
+                .carbonItemId(savedItem.getId())  // 저장된 ID 포함
+                .name(savedItem.getName())
+                .category(savedItem.getCategory())
+                .categoryKorean(analysis.getCategoryKorean())
+                .carbonGrams(savedItem.getCarbonValue())
+                .growthPoint(savedItem.getGrowthPoint())
+                .explanation(savedItem.getExplanation())
+                .categoryImageUrl(savedItem.getCategory().getImageUrl())
                 .build();
     }
 }

--- a/server/src/main/java/com/soopgyeol/api/service/gpt/AIChallengeSearchService.java
+++ b/server/src/main/java/com/soopgyeol/api/service/gpt/AIChallengeSearchService.java
@@ -1,0 +1,8 @@
+package com.soopgyeol.api.service.gpt;
+
+import com.soopgyeol.api.domain.carbon.dto.CarbonAnalysisResponse;
+import com.soopgyeol.api.domain.enums.Category;
+
+public interface AIChallengeSearchService {
+    CarbonAnalysisResponse analyzeWithFixedCategory(String keyword, Category category);
+}

--- a/server/src/main/java/com/soopgyeol/api/service/gpt/AIChallengeSearchServiceImpl.java
+++ b/server/src/main/java/com/soopgyeol/api/service/gpt/AIChallengeSearchServiceImpl.java
@@ -1,0 +1,102 @@
+package com.soopgyeol.api.service.gpt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soopgyeol.api.domain.carbon.dto.CarbonAnalysisResponse;
+import com.soopgyeol.api.domain.enums.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AIChallengeSearchServiceImpl implements AIChallengeSearchService {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${OPENAI_API_KEY}")
+    private String apiKey;
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    @Override
+    public CarbonAnalysisResponse analyzeWithFixedCategory(String keyword, Category fixedCategory) {
+        String systemPrompt = """
+                너는 탄소 분석 시스템이야. 사용자의 입력을 받고 다음 형식으로 JSON으로 대답해.
+                품목명과, 탄소량 설명은 반드시 한글로 대답해줘.
+                
+                "growthPoint"는 사용자의 해당 활동 또는 소비에 따라서 탄소가 절감되는 정도를 너가 판단해서 0~20점 사이로 점수를 줘.
+                ETC는 탄소량, growthPoint 모두 0점으로 줘.
+
+                {
+                  "name": (품목명, 한글),
+                  "carbonGrams": (사용자의 입력에 따라 탄소 소비량을 분석해서 반환, 숫자, g 단위),
+                  "growthPoint": (숫자, 정수 단위),
+                  "explanation": (왜 이 탄소량이 나왔는지 설명. 30자 이내로 간결하게 작성)
+                }
+                """;
+
+        List<Object> messages = List.of(
+                buildMessage("system", systemPrompt),
+                buildMessage("user", keyword)
+        );
+
+        String requestBody = String.format("""
+            {
+              "model": "gpt-3.5-turbo",
+              "messages": %s,
+              "temperature": 0.2
+            }
+        """, toJson(messages));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                OPENAI_API_URL,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        try {
+            JsonNode root = objectMapper.readTree(response.getBody());
+            String content = root.path("choices").get(0).path("message").path("content").asText();
+            JsonNode json = objectMapper.readTree(content);
+
+            return CarbonAnalysisResponse.builder()
+                    .name(json.get("name").asText())
+                    .carbonGrams(json.get("carbonGrams").asDouble())
+                    .growthPoint(json.get("growthPoint").asInt())
+                    .explanation(json.get("explanation").asText())
+                    .category(fixedCategory) // GPT로부터 받지 않고 직접 삽입
+                    .build();
+
+        } catch (Exception e) {
+            throw new RuntimeException("챌린지 GPT 응답 파싱 실패", e);
+        }
+    }
+
+    private Object buildMessage(String role, String content) {
+        return new HashMap<>() {{
+            put("role", role);
+            put("content", content);
+        }};
+    }
+
+    private String toJson(Object obj) {
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("JSON 직렬화 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
### ⛓️‍💥 Issue Number
- #61 


  <br/>
### 🔎 Summary

- AI가 생성한 챌린지를 사용자가 확인하고, 포인트 받기를 눌렀을 시 탄소 검색 화면으로 이동하는 기능
- 생성된 챌린지 기반으로 키워드를 보내고, 결과를 반환
- 검색 결과 화면에 카테고리별 이미지도 반환하도록 추가하였음. (챌린지 / 일반 검색 모두)

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제

  <br/>
### ✅ PR 체크 리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
- [ ] test workflow가 정상적으로 작동했습니다.